### PR TITLE
Mjberry/update readmes for new gene mapping file

### DIFF
--- a/pipeline_readmes/README-FP.md
+++ b/pipeline_readmes/README-FP.md
@@ -1,4 +1,4 @@
-This file contains a description of the different output files of the feature prioritization (FP) pipeline. The downloaded zip archive will contain up to nine other files for users to further examine and understand their results.  These other files are:
+This file contains a description of the different output files of the feature prioritization (FP) pipeline. The downloaded zip archive will contain up to eight other files for users to further examine and understand their results.  These other files are:
 
 #### Results Files
 - A) features_ranked_per_phenotype - Scores for Ranked Features for Each Phenotype
@@ -8,10 +8,9 @@ This file contains a description of the different output files of the feature pr
 - C) clean_features_matrix.txt - Features Spreadsheet File
 - D) clean_phenotypic_matrix.txt - Processed Phenotype Spreadsheet File
 - E) gene_map.txt - Gene ID Mapping File (if KN guided analysis)
-- F) gene_map_exceptions.txt - Gene ID Mapping Exceptions File (if KN guided analysis)
-- G) run_params.yml - Run Parameters File
-- H) run_cleanup_params.yml - Cleanup Run Parameters File
-- I) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
+- F) run_params.yml - Run Parameters File
+- G) run_cleanup_params.yml - Cleanup Run Parameters File
+- H) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
 
 Below are descriptions for the contents of each of these files:
 
@@ -129,21 +128,16 @@ visualization_score: The min-max normalized value of quantitative_sorting_score.
 
 #### E) gene_map.txt - Gene ID Mapping File (if KN guided analysis)
 - The columns of this file are defined as follows:
-  1) KN_gene_id: the stable Ensembl gene ID that KnowEnG uses internally
-  2) user_gene_id: the corresponding gene/transcript/protein identifier supplied by the user in the original genomic spreadsheet.
+  1) user_supplied_gene_name: the gene/transcript/protein identifier supplied by the user in the original genomic spreadsheet.
+  2) status: if the user-supplied gene name could be mapped to a stable Ensembl gene ID, this column will contain the Ensembl gene ID; otherwise, this column will contain the reason mapping failed ("unmapped-none" if no match was found, or "unmapped-many" if multiple matches were found).
 
-#### F) gene_map_exceptions.txt - Gene ID Mapping Exceptions File (if KN guided analysis)
-- The columns of this file are defined as follows:
-  1) user_gene_id: the gene/transcript/protein identifier supplied by the user in the original genomic spreadsheet.
-  2) error_code: the reason the user_gene_id was not mapped to a stable Ensembl gene ID.
-
-#### G) run_params.yml - Run Parameters File
+#### F) run_params.yml - Run Parameters File
 - This yaml file contains the run parameters file that was used by the computation container that ran the KnowEnG analysis pipeline (implementation available on GitHub) on the input data.
 
-#### H) run_cleanup_params.yml - Cleanup Run Parameters File
+#### G) run_cleanup_params.yml - Cleanup Run Parameters File
 - This yaml file contains the run parameters file that was used by the computation container that ran the KnowEnG data-cleanup pipeline (implementation available on GitHub) on the input data.
 
-#### I) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
+#### H) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
 - This yaml file contains information about the interaction network if used in the analysis.  Its keys include summarizations about the network size (“data”), its public data source details (“datasets”), information about the meaning of its edges (“edge_type”), and some commands and configurations used in its construction (“export”).
 
 The licensing terms of the source code and containers to perform this analysis can be found at https://knoweng.github.io/. Licensing information relating to the data in the Knowledge Network can be found https://knoweng.org/kn-data-references/#kn_data_resources. 

--- a/pipeline_readmes/README-FP.md
+++ b/pipeline_readmes/README-FP.md
@@ -1,19 +1,19 @@
 This file contains a description of the different output files of the feature prioritization (FP) pipeline. The downloaded zip archive will contain up to seven other files for users to further examine and understand their results.  These other files are:
 
 #### Results Files
-- A) genes_ranked_per_phenotype - Scores for Ranked Genes for Each Phenotype
-- B) top_genes_by_phenotype_matrix - Top Ranked Gene Sets per Phenotype
+- A) features_ranked_per_phenotype - Scores for Ranked Features for Each Phenotype
+- B) top_features_by_phenotype_matrix - Top Ranked Feature Sets per Phenotype
 
 #### Reference Files
-- C) clean_genomic_matrix.txt - Mapped Genomic Spreadsheet File
+- C) clean_features_matrix.txt - Features Spreadsheet File (mapped if KN guided analysis)
 - D) clean_phenotypic_matrix.txt - Processed Phenotype Spreadsheet File
-- E) gene_map.txt - Gene ID Mapping File
+- E) gene_map.txt - Gene ID Mapping File (if KN guided analysis)
 - F) run_params.yml - Run Parameters File
 - G) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
 
 Below are descriptions for the contents of each of these files:
 
-#### A) genes_ranked_per_phenotype - Scores for Ranked Genes for Each Phenotype
+#### A) features_ranked_per_phenotype - Scores for Ranked Features for Each Phenotype
 The output format of this file will depend on the choices you made in configuring the analysis.
 
 ##### Option 1 (Pearson Correlation): 
@@ -23,10 +23,10 @@ The output format of this file will depend on the choices you made in configurin
   - Use bootstrapping = No
 - Output Format  :
   1) Response: Name of the phenotype of interest.
-  2) Gene_ENSEMBL_ID: The ENSEMBL ID of the gene.
-  3) quantitative_sorting_score: The absolute value of the Pearson correlation coefficient between the phenotype and the gene.  A higher value shows the gene is more relevant to the phenotype. This value is between 0 and 1.
+  2) Feature_ID: The feature identifier.
+  3) quantitative_sorting_score: The absolute value of the Pearson correlation coefficient between the phenotype and the feature.  A higher score shows the feature is more relevant to the phenotype. This value is between 0 and 1.
   4) visualization_score: The min-max normalized value of quantitative_sorting_score. This value is always between 0 and 1.
-  5) baseline_score: The Pearson correlation coefficient between the phenotype and the gene.
+  5) baseline_score: The Pearson correlation coefficient between the phenotype and the feature.
 
 ##### Option 2 (Robust Pearson Correlation):
 - Choices:
@@ -35,10 +35,10 @@ The output format of this file will depend on the choices you made in configurin
   - Use bootstrapping = Yes
 - Output Format:
   1) Response: Name of the phenotype of interest.
-  2) Gene_ENSEMBL_ID: The ENSEMBL ID of the gene.
-  3) quantitative_sorting_score: The aggregate score of the gene.  This score is obtained by aggregating ranked lists of genes using Borda method. Each ranked list corresponds to one instance of bootstrap sampling and is ranked using the absolute Pearson correlation coefficient. A higher value shows the gene is more relevant to the phenotype. This value is always between 1 and the total number of genes.
+  2) Feature_ID: The feature identifier.
+  3) quantitative_sorting_score: The aggregate score of the feature.  This score is obtained by aggregating ranked lists of features using Borda method. Each ranked list corresponds to one instance of bootstrap sampling and is ranked using the absolute Pearson correlation coefficient. A higher score shows the feature is more relevant to the phenotype. This value is always between 1 and the total number of features.
   4) visualization_score: The min-max normalized value of quantitative_sorting_score. This value is always between 0 and 1.
-  5) baseline_score: The Pearson correlation coefficient between the phenotype and the gene.
+  5) baseline_score: The Pearson correlation coefficient between the phenotype and the feature.
 
 ##### Option 3 (ProGENI Pearson):
 - Choices:
@@ -48,7 +48,7 @@ The output format of this file will depend on the choices you made in configurin
 - Output Format: 
   1) Response: Name of the phenotype of interest.
   2) Gene_ENSEMBL_ID: The ENSEMBL ID of the gene.
-  3) quantitative_sorting_score: The ProGENI score of the gene.  A higher value shows the gene is more relevant to the phenotype. This value is always between -1 and 1.
+  3) quantitative_sorting_score: The ProGENI score of the gene.  A higher score shows the gene is more relevant to the phenotype. This value is always between -1 and 1.
   4) visualization_score: The min-max normalized value of quantitative_sorting_score. This value is always between 0 and 1.
   5) baseline_score: The Pearson correlation coefficient between the phenotype and the gene.
   6) Percent_appearing_in_restart_set: Multiplying this number with 100 gives the percent of the bootstrapping instances in which this gene was used in the restart set of ProGENI. Since no bootstrapping was done in this option, these values are either 0 or 1.
@@ -61,7 +61,7 @@ The output format of this file will depend on the choices you made in configurin
 - Output Format: 
   1) Response: Name of the phenotype of interest.
   2) Gene_ENSEMBL_ID: The ENSEMBL ID of the gene.
-  3) quantitative_sorting_score: The aggregate score of the gene.  This score is obtained by aggregating ranked lists of genes using Borda method. Each ranked list corresponds to one instance of bootstrap sampling and is ranked using the ProGENI score. A higher value shows the gene is more relevant to the phenotype. This value is always between 1 and the total number of genes.
+  3) quantitative_sorting_score: The aggregate score of the gene.  This score is obtained by aggregating ranked lists of genes using Borda method. Each ranked list corresponds to one instance of bootstrap sampling and is ranked using the ProGENI score. A higher score shows the gene is more relevant to the phenotype. This value is always between 1 and the total number of genes.
   4) visualization_score: The min-max normalized value of quantitative_sorting_score. This value is always between 0 and 1.
   5) baseline_score: The Pearson correlation coefficient between the phenotype and the gene.
   6) Percent_appearing_in_restart_set: Multiplying this number with 100 gives the percent of the bootstrapping instances in which this gene was used in the restart set of ProGENI.
@@ -73,10 +73,10 @@ The output format of this file will depend on the choices you made in configurin
   - Use bootstrapping = No
 - Output Format: 
   1) Response: Name of the phenotype of interest.
-  2) Gene_ENSEMBL_ID: The ENSEMBL ID of the gene.
-  3) quantitative_sorting_score: The absolute value of the T-statistic.  A higher value shows the gene is more differentially expressed. 
+  2) Feature_ID: The feature identifier.
+  3) quantitative_sorting_score: The absolute value of the T-statistic.  A higher score shows the feature is more differentially valued. 
   4) visualization_score: The min-max normalized value of quantitative_sorting_score. This value is always between 0 and 1.
-  5) baseline_score: The T-statistic for each gene obtained by comparing gene expression for the two phenotype options.
+  5) baseline_score: The T-statistic for each feature obtained by comparing feature values for the two phenotype options.
 
 ##### Option 6 (Robust T-test):
 - Choices:
@@ -85,10 +85,10 @@ The output format of this file will depend on the choices you made in configurin
   - Use bootstrapping = Yes
 - Output Format: 
   1) Response: Name of the phenotype of interest.
-  2) Gene_ENSEMBL_ID: The ENSEMBL ID of the gene.
-  3) quantitative_sorting_score: The aggregate score of the gene.  This score is obtained by aggregating ranked lists of genes using Borda method. Each ranked list corresponds to one instance of bootstrap sampling and is ranked using the absolute value of the T-statistic. A higher value shows the gene is more differentially expressed. This value is always between 1 and the total number of genes.
+  2) Feature_ID: The feature identifier.
+  3) quantitative_sorting_score: The aggregate score of the feature.  This score is obtained by aggregating ranked lists of features using Borda method. Each ranked list corresponds to one instance of bootstrap sampling and is ranked using the absolute value of the T-statistic. A higher score shows the feature is more differentially valued. This value is always between 1 and the total number of features.
   4) visualization_score: The min-max normalized value of quantitative_sorting_score. This value is always between 0 and 1.
-  5) baseline_score: The T-statistic for each gene obtained by comparing gene expression for the two phenotype options.
+  5) baseline_score: The T-statistic for each feature obtained by comparing feature values for the two phenotype options.
 
 ##### Option 7 (ProGENI T-test):
 - Choices:
@@ -98,7 +98,7 @@ The output format of this file will depend on the choices you made in configurin
 - Output Format: 
   1) Response: Name of the phenotype of interest.
   2) Gene_ENSEMBL_ID: The ENSEMBL ID of the gene.
-  3) quantitative_sorting_score: The ProGENI score of the gene.  A higher value shows the gene is more relevant to the phenotype. This value is always between -1 and 1.
+  3) quantitative_sorting_score: The ProGENI score of the gene.  A higher score shows the gene is more relevant to the phenotype. This value is always between -1 and 1.
 visualization_score: The min-max normalized value of quantitative_sorting_score. This value is always between 0 and 1.
   4) baseline_score: The T-statistic for each gene obtained by comparing gene expression for the two phenotype options.
   5) Percent_appearing_in_restart_set: Multiplying this number with 100 gives the percent of the bootstrapping instances in which this gene was used in the restart set of ProGENI. Since no bootstrapping was done in this option, these values are either 0 or 1.
@@ -111,21 +111,21 @@ visualization_score: The min-max normalized value of quantitative_sorting_score.
 - Output Format: 
   1) Response: Name of the phenotype of interest.
   2) Gene_ENSEMBL_ID: The ENSEMBL ID of the gene.
-  3) quantitative_sorting_score: The aggregate score of the gene.  This score is obtained by aggregating ranked lists of genes using Borda method. Each ranked list corresponds to one instance of bootstrap sampling and is ranked using the ProGENI score. A higher value shows the gene is more relevant to the phenotype. This value is always between 1 and the total number of genes.
+  3) quantitative_sorting_score: The aggregate score of the gene.  This score is obtained by aggregating ranked lists of genes using Borda method. Each ranked list corresponds to one instance of bootstrap sampling and is ranked using the ProGENI score. A higher score shows the gene is more relevant to the phenotype. This value is always between 1 and the total number of genes.
   4) visualization_score: The min-max normalized value of quantitative_sorting_score. This value is always between 0 and 1.
   5) baseline_score: The T-statistic for each gene obtained by comparing gene expression for the two phenotype options.
   6) Percent_appearing_in_restart_set: Multiplying this number with 100 gives the percent of the bootstrapping instances in which this gene was used in the restart set of ProGENI.
 
-#### B) top_genes_by_phenotype_matrix - Top Ranked Gene Sets per Phenotype
-- This file contains a matrix with the phenotype names as the column headers and stable Ensembl gene_ids as the rows. A ‘1’ in this table indicates that the row gene was one of the top 100 ranking (highest scoring) genes for that specific column phenotype using the method of choice.  All other values are 0. This file can be used in the Gene Set Characterization pipeline.
+#### B) top_features_by_phenotype_matrix - Top Ranked Feature Sets per Phenotype
+- This file contains a matrix with the phenotype names as the column headers and the feature identifiers as the rows. If the KN was used in the analysis, the feature identifiers will be the stable Ensembl gene_ids. A ‘1’ in this table indicates that the row feature was one of the top 100 ranking (highest scoring) features for that specific column phenotype using the method of choice.  All other values are 0. If the features are genes, this file can be used in the Gene Set Characterization pipeline.
 
-#### C) clean_genomic_matrix.txt - Mapped Genomic Spreadsheet File
-- This file contains a modified version of the user’s input genomic matrix where the original gene identifiers provided have been mapped to stable Ensembl gene_ids where possible.  When using the Knowledge Network guided analysis, rows with original gene names that are unable to be mapped or are not unique are discarded from this clean output.
+#### C) clean_features_matrix.txt - Features Spreadsheet File
+- This file contains the user's input feature matrix. If the KN was used in the analysis, the original gene identifiers provided are mapped to stable Ensembl gene_ids where possible, and rows with original gene names that are unable to be mapped or are not unique are discarded from this clean output.
 
 #### D) clean_phenotypic_matrix.txt - Mapped Genomic Spreadsheet File
 - This file contains a modified version of the user’s input phenotypic matrix where foreign characters are removed and NAs are notated with a specific value.
 
-#### E) gene_map.txt - Gene ID Mapping File
+#### E) gene_map.txt - Gene ID Mapping File (if KN guided analysis)
 - The columns of this file are defined as follows:
   1) KN_gene_id: the stable Ensembl gene ID that KnowEnG uses internally
   2) user_gene_id: the corresponding gene/transcript/protein identifier supplied by the user in the original genomic spreadsheet.

--- a/pipeline_readmes/README-FP.md
+++ b/pipeline_readmes/README-FP.md
@@ -1,15 +1,17 @@
-This file contains a description of the different output files of the feature prioritization (FP) pipeline. The downloaded zip archive will contain up to seven other files for users to further examine and understand their results.  These other files are:
+This file contains a description of the different output files of the feature prioritization (FP) pipeline. The downloaded zip archive will contain up to nine other files for users to further examine and understand their results.  These other files are:
 
 #### Results Files
 - A) features_ranked_per_phenotype - Scores for Ranked Features for Each Phenotype
 - B) top_features_by_phenotype_matrix - Top Ranked Feature Sets per Phenotype
 
 #### Reference Files
-- C) clean_features_matrix.txt - Features Spreadsheet File (mapped if KN guided analysis)
+- C) clean_features_matrix.txt - Features Spreadsheet File
 - D) clean_phenotypic_matrix.txt - Processed Phenotype Spreadsheet File
 - E) gene_map.txt - Gene ID Mapping File (if KN guided analysis)
-- F) run_params.yml - Run Parameters File
-- G) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
+- F) gene_map_exceptions.txt - Gene ID Mapping Exceptions File (if KN guided analysis)
+- G) run_params.yml - Run Parameters File
+- H) run_cleanup_params.yml - Cleanup Run Parameters File
+- I) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
 
 Below are descriptions for the contents of each of these files:
 
@@ -21,7 +23,7 @@ The output format of this file will depend on the choices you made in configurin
   - Primary prioritization method = Absolute Pearson Correlation
   - Use knowledge Network = No
   - Use bootstrapping = No
-- Output Format  :
+- Output Format:
   1) Response: Name of the phenotype of interest.
   2) Feature_ID: The feature identifier.
   3) quantitative_sorting_score: The absolute value of the Pearson correlation coefficient between the phenotype and the feature.  A higher score shows the feature is more relevant to the phenotype. This value is between 0 and 1.
@@ -47,7 +49,7 @@ The output format of this file will depend on the choices you made in configurin
   - Use bootstrapping = No
 - Output Format: 
   1) Response: Name of the phenotype of interest.
-  2) Gene_ENSEMBL_ID: The ENSEMBL ID of the gene.
+  2) Feature_ID: The feature identifier.
   3) quantitative_sorting_score: The ProGENI score of the gene.  A higher score shows the gene is more relevant to the phenotype. This value is always between -1 and 1.
   4) visualization_score: The min-max normalized value of quantitative_sorting_score. This value is always between 0 and 1.
   5) baseline_score: The Pearson correlation coefficient between the phenotype and the gene.
@@ -60,7 +62,7 @@ The output format of this file will depend on the choices you made in configurin
   - Use bootstrapping = Yes
 - Output Format: 
   1) Response: Name of the phenotype of interest.
-  2) Gene_ENSEMBL_ID: The ENSEMBL ID of the gene.
+  2) Feature_ID: The feature identifier.
   3) quantitative_sorting_score: The aggregate score of the gene.  This score is obtained by aggregating ranked lists of genes using Borda method. Each ranked list corresponds to one instance of bootstrap sampling and is ranked using the ProGENI score. A higher score shows the gene is more relevant to the phenotype. This value is always between 1 and the total number of genes.
   4) visualization_score: The min-max normalized value of quantitative_sorting_score. This value is always between 0 and 1.
   5) baseline_score: The Pearson correlation coefficient between the phenotype and the gene.
@@ -97,7 +99,7 @@ The output format of this file will depend on the choices you made in configurin
   - Use bootstrapping = No
 - Output Format: 
   1) Response: Name of the phenotype of interest.
-  2) Gene_ENSEMBL_ID: The ENSEMBL ID of the gene.
+  2) Feature_ID: The feature identifier.
   3) quantitative_sorting_score: The ProGENI score of the gene.  A higher score shows the gene is more relevant to the phenotype. This value is always between -1 and 1.
 visualization_score: The min-max normalized value of quantitative_sorting_score. This value is always between 0 and 1.
   4) baseline_score: The T-statistic for each gene obtained by comparing gene expression for the two phenotype options.
@@ -110,19 +112,19 @@ visualization_score: The min-max normalized value of quantitative_sorting_score.
   - Use bootstrapping = Yes
 - Output Format: 
   1) Response: Name of the phenotype of interest.
-  2) Gene_ENSEMBL_ID: The ENSEMBL ID of the gene.
+  2) Feature_ID: The feature identifier.
   3) quantitative_sorting_score: The aggregate score of the gene.  This score is obtained by aggregating ranked lists of genes using Borda method. Each ranked list corresponds to one instance of bootstrap sampling and is ranked using the ProGENI score. A higher score shows the gene is more relevant to the phenotype. This value is always between 1 and the total number of genes.
   4) visualization_score: The min-max normalized value of quantitative_sorting_score. This value is always between 0 and 1.
   5) baseline_score: The T-statistic for each gene obtained by comparing gene expression for the two phenotype options.
   6) Percent_appearing_in_restart_set: Multiplying this number with 100 gives the percent of the bootstrapping instances in which this gene was used in the restart set of ProGENI.
 
 #### B) top_features_by_phenotype_matrix - Top Ranked Feature Sets per Phenotype
-- This file contains a matrix with the phenotype names as the column headers and the feature identifiers as the rows. If the KN was used in the analysis, the feature identifiers will be the stable Ensembl gene_ids. A ‘1’ in this table indicates that the row feature was one of the top 100 ranking (highest scoring) features for that specific column phenotype using the method of choice.  All other values are 0. If the features are genes, this file can be used in the Gene Set Characterization pipeline.
+- This file contains a matrix with the phenotype names as the column headers and the feature identifiers as the rows. A ‘1’ in this table indicates that the row feature was one of the top 100 ranking (highest scoring) features for that specific column phenotype using the method of choice.  All other values are 0. If the features are genes, this file can be used in the Gene Set Characterization pipeline.
 
 #### C) clean_features_matrix.txt - Features Spreadsheet File
-- This file contains the user's input feature matrix. If the KN was used in the analysis, the original gene identifiers provided are mapped to stable Ensembl gene_ids where possible, and rows with original gene names that are unable to be mapped or are not unique are discarded from this clean output.
+- This file contains the user's input feature matrix. If the KN was used in the analysis, rows with gene names that are unable to be mapped or are not unique are discarded from this clean output.
 
-#### D) clean_phenotypic_matrix.txt - Mapped Genomic Spreadsheet File
+#### D) clean_phenotypic_matrix.txt - Processed Phenotype Spreadsheet File
 - This file contains a modified version of the user’s input phenotypic matrix where foreign characters are removed and NAs are notated with a specific value.
 
 #### E) gene_map.txt - Gene ID Mapping File (if KN guided analysis)
@@ -130,10 +132,18 @@ visualization_score: The min-max normalized value of quantitative_sorting_score.
   1) KN_gene_id: the stable Ensembl gene ID that KnowEnG uses internally
   2) user_gene_id: the corresponding gene/transcript/protein identifier supplied by the user in the original genomic spreadsheet.
 
-#### F) run_params.yml - Run Parameters File
-- This yaml file contains the run parameters file that was used by the computation container that ran the KnowEnG pipeline (implementation available on GitHub) on the input data.
+#### F) gene_map_exceptions.txt - Gene ID Mapping Exceptions File (if KN guided analysis)
+- The columns of this file are defined as follows:
+  1) user_gene_id: the gene/transcript/protein identifier supplied by the user in the original genomic spreadsheet.
+  2) error_code: the reason the user_gene_id was not mapped to a stable Ensembl gene ID.
 
-#### G) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
+#### G) run_params.yml - Run Parameters File
+- This yaml file contains the run parameters file that was used by the computation container that ran the KnowEnG analysis pipeline (implementation available on GitHub) on the input data.
+
+#### H) run_cleanup_params.yml - Cleanup Run Parameters File
+- This yaml file contains the run parameters file that was used by the computation container that ran the KnowEnG data-cleanup pipeline (implementation available on GitHub) on the input data.
+
+#### I) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
 - This yaml file contains information about the interaction network if used in the analysis.  Its keys include summarizations about the network size (“data”), its public data source details (“datasets”), information about the meaning of its edges (“edge_type”), and some commands and configurations used in its construction (“export”).
 
 The licensing terms of the source code and containers to perform this analysis can be found at https://knoweng.github.io/. Licensing information relating to the data in the Knowledge Network can be found https://knoweng.org/kn-data-references/#kn_data_resources. 

--- a/pipeline_readmes/README-GSC.md
+++ b/pipeline_readmes/README-GSC.md
@@ -1,4 +1,4 @@
-This file contains a description of the different output files of the gene set characterization (GSC) pipeline. The downloaded zip file will contain up to nine other reference files. The format of some output files will vary depending on the parameter options selected.
+This file contains a description of the different output files of the gene set characterization (GSC) pipeline. The downloaded zip file will contain up to eight other reference files. The format of some output files will vary depending on the parameter options selected.
 
 #### Results File
  - A) gsc_results.txt - Gene Set Characterization Results File
@@ -6,12 +6,11 @@ This file contains a description of the different output files of the gene set c
 #### Reference Files:
  - B) clean_gene_set_matrix.txt - Mapped Genomic Spreadsheet File
  - C) gene_map.txt - Gene ID Mapping File
- - D) gene_map_exceptions.txt - Gene ID Mapping Exceptions File
- - E) dropped_genes.txt - Dropped Genes File
- - F) run_params.yml - Run Parameters File
- - G) run_cleanup_params.yml - Cleanup Run Parameters File
- - H) property_networks.metadata - Gene Set Collection Metadata 
- - I) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
+ - D) dropped_genes.txt - Dropped Genes File
+ - E) run_params.yml - Run Parameters File
+ - F) run_cleanup_params.yml - Cleanup Run Parameters File
+ - G) property_networks.metadata - Gene Set Collection Metadata 
+ - H) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
 
 Below are descriptions for the contents of each of these files:
 
@@ -43,30 +42,25 @@ Below are descriptions for the contents of each of these files:
 
 #### C) gene_map.txt - Gene ID Mapping File
 - The columns of this file are defined as follows:
-  1) KN_gene_id: the stable Ensembl gene ID that KnowEnG uses internally
-  2) user_gene_id: the corresponding gene/transcript/protein identifier supplied by the user in the original genomic spreadsheet.
+  1) user_supplied_gene_name: the gene/transcript/protein identifier supplied by the user in the original genomic spreadsheet.
+  2) status: if the user-supplied gene name could be mapped to a stable Ensembl gene ID, this column will contain the Ensembl gene ID; otherwise, this column will contain the reason mapping failed ("unmapped-none" if no match was found, or "unmapped-many" if multiple matches were found).
 
-#### D) gene_map_exceptions.txt - Gene ID Mapping Exceptions File (if KN guided analysis)
-- The columns of this file are defined as follows:
-  1) user_gene_id: the gene/transcript/protein identifier supplied by the user in the original genomic spreadsheet.
-  2) error_code: the reason the user_gene_id was not mapped to a stable Ensembl gene ID.
-
-#### E) dropped_genes.txt - Dropped Genes File
+#### D) dropped_genes.txt - Dropped Genes File
 - The columns of this file are defined as follows:
   1) collection: the public gene set collection whose processing required dropping the gene
   2) gene_name: the gene identifier as provided by the user in the original input
   3) gene_id: the stable Ensembl gene ID for the gene_name
 
-#### F) run_params.yml - Run Parameters File
+#### E) run_params.yml - Run Parameters File
 - This yaml file contains the run parameters that were used by the computation container that ran the KnowEnG analysis pipeline (implementation available on GitHub) on the input data. The file contains one block of parameters per public gene set collection.
 
-#### G) run_cleanup_params.yml - Cleanup Run Parameters File
+#### F) run_cleanup_params.yml - Cleanup Run Parameters File
 - This yaml file contains the run parameters file that was used by the computation container that ran the KnowEnG data-cleanup pipeline (implementation available on GitHub) on the input data.
 
-#### H) property_networks.metadata - Gene Set Collection Metadata 
+#### G) property_networks.metadata - Gene Set Collection Metadata 
 - This yaml file contains information about the gene set collection used for the results.  There is one block per public gene set collection, and within each block, keys include summarizations about the network size (“data”), its public data source details (“datasets”), information about the meaning of its edges (“edge_type”), and some commands and configurations used in its construction (“export”).
 
-#### I) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
+#### H) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
 - This yaml file contains information about the interaction network if used in the analysis.  Its keys include summarizations about the network size (“data”), its public data source details (“datasets”), information about the meaning of its edges (“edge_type”), and some commands and configurations used in its construction (“export”).
 
 The licensing terms of the source code and containers to perform this analysis can be found at https://knoweng.github.io/. Licensing information relating to the data in the Knowledge Network can be found https://knoweng.org/kn-data-references/#kn_data_resources. 

--- a/pipeline_readmes/README-GSC.md
+++ b/pipeline_readmes/README-GSC.md
@@ -1,15 +1,17 @@
-This file contains a description of the different output files of the gene set characterization (GSC) pipeline. The downloaded zip file will contain one directory for each public gene set collection that was selected during the analysis configuration as well as up to three other reference files. The format of some output files will vary depending on the parameter options selected.
+This file contains a description of the different output files of the gene set characterization (GSC) pipeline. The downloaded zip file will contain up to nine other reference files. The format of some output files will vary depending on the parameter options selected.
 
-#### Files in Gene Set Collection Directory:
+#### Results File
  - A) gsc_results.txt - Gene Set Characterization Results File
- - B) gene_set_name_map.txt - Public Gene Set Mapping File
- - C) run_params.yml - Run Parameters File
- - D) *.metadata - Gene Set Collection Metadata 
 
-#### Other Reference Files:
- - E) clean_genomic_matrix.txt - Mapped Genomic Spreadsheet File
- - F) gene_map.txt - Gene ID Mapping File
- - G) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
+#### Reference Files:
+ - B) clean_gene_set_matrix.txt - Mapped Genomic Spreadsheet File
+ - C) gene_map.txt - Gene ID Mapping File
+ - D) gene_map_exceptions.txt - Gene ID Mapping Exceptions File
+ - E) dropped_genes.txt - Dropped Genes File
+ - F) run_params.yml - Run Parameters File
+ - G) run_cleanup_params.yml - Cleanup Run Parameters File
+ - H) property_networks.metadata - Gene Set Collection Metadata 
+ - I) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
 
 Below are descriptions for the contents of each of these files:
 
@@ -17,44 +19,54 @@ Below are descriptions for the contents of each of these files:
 - The columns of this file will depend on the choice you made whether to "Use the Knowledge Network"
 - If "Yes" Option (DRaWR):
   1) user_gene_set: the names of the gene sets that you submitted
-  2) property_gene_set: the internal KnowEnG ids for public gene sets from one public gene set collection
-  3) difference_score: difference of query_score (col4) and baseline_score(col5) divided by the largest difference in the file. This value is between 0 and 1 and reported when it is greater than 0.5
-  4) query_score: converged stationary probability of being at the property_gene_set node in the chosen heterogenous network given that you restart at any only gene node from the user gene set. This value is between 0 and 1.
-  5) baseline_score: converged stationary probability of being at the property_gene_set node in the chosen heterogenous network given that you restart at any gene node. This value is between 0 and 1.
+  2) property_gene_set_id: the internal KnowEnG ids for public gene sets from one public gene set collection
+  3) property_gene_set_alias: alias for the gene set from its original data source
+  4) property_gene_set_description: description for the gene set from its original data source
+  5) difference_score: difference of query_score (col4) and baseline_score(col5) divided by the largest difference in the file. This value is between 0 and 1 and reported when it is greater than 0.5
+  6) query_score: converged stationary probability of being at the property_gene_set node in the chosen heterogenous network given that you restart at any only gene node from the user gene set. This value is between 0 and 1.
+  7) baseline_score: converged stationary probability of being at the property_gene_set node in the chosen heterogenous network given that you restart at any gene node. This value is between 0 and 1.
 - If "No" Option (Fisher Exact):
   1) user_gene_set: the names of the gene sets that you submitted
-  2) property_gene_set: the internal KnowEnG ids for public gene sets from one public gene set collection
-  3) pvalue: the -1 * log10 pvalue of the one sided (alternative = 'greater') Fisher Exact Test using the contingency table corresponding to the user set and property gene set of the row. This value is reported when it is greater than 2.
+  2) property_gene_set_id: the internal KnowEnG ids for public gene sets from one public gene set collection
+  3) property_gene_set_alias: alias for the gene set from its original data source
+  4) property_gene_set_description: description for the gene set from its original data source
+  5) pvalue: the -1 * log10 pvalue of the one sided (alternative = 'greater') Fisher Exact Test using the contingency table corresponding to the user set and property gene set of the row. This value is reported when it is greater than 2.
       + NOTE1: You can take 10^-x to convert these values back into the original pvalues.
       + NOTE2: These pvalues (-1*log10) have not been corrected for multiple hypothesis testing.
-  4) universe_count: total number of genes annotated by the public gene set collection and listed in your spreadsheet (or known for the species of your submitted gene list).
-  5) user_count: size of your gene set in the universe
-  6) property_count: size of the public gene set in the universe
-  7) overlap_count: size of the overlap between the two in the universe
+  6) universe_count: total number of genes annotated by the public gene set collection and listed in your spreadsheet (or known for the species of your submitted gene list).
+  7) user_count: size of your gene set in the universe
+  8) property_count: size of the public gene set in the universe
+  9) overlap_count: size of the overlap between the two in the universe
 
-#### B) gene_set_name_map.txt - Public Gene Set Mapping File
-- The columns of this file are defined as follows:
-  1) property_gene_set_id: the internal KnowEnG id for a the public gene set
-  2) property_gene_set_id2: the internal KnowEnG id for a the public gene set
-  3) gene_set_type: will always be “Property”
-  4) property_gene_set_alias: alias for gene set from original data source
-  5) property_gene_set_desc: description for gene set from original data source
+#### B) clean_gene_set_matrix.txt - Mapped Genomic Spreadsheet File
+- This file contains a modified version of the user’s input genomic matrix. Rows whose gene names could not be mapped to stable Ensembl gene IDs or are not unique are discarded from this clean output.  Only the remaining genes are used for the gene universe for the gene set characterization method.
 
-#### C) run_params.yml - Run Parameters File
-- This yaml file contains the run parameters file that was used by the computation container that ran the KnowEnG pipeline (implementation available on GitHub) on the input data.
-
-#### D) *.metadata - Gene Set Collection Metadata 
-- This yaml file contains information about the gene set collection used for the results in this directory.  Its keys include summarizations about the network size (“data”), its public data source details (“datasets”), information about the meaning of its edges (“edge_type”), and some commands and configurations used in its construction (“export”).
-
-#### E) clean_genomic_matrix.txt - Mapped Genomic Spreadsheet File
-- This file contains a modified version of the user’s input genomic matrix where the original gene identifiers provided have been mapped to stable Ensembl gene_ids where possible.  Rows with original gene names that are unable to be mapped or are not unique are discarded from this clean output.  Only the remaining genes are used for the gene universe for the gene set characterization method.
-
-#### F) gene_map.txt - Gene ID Mapping File
+#### C) gene_map.txt - Gene ID Mapping File
 - The columns of this file are defined as follows:
   1) KN_gene_id: the stable Ensembl gene ID that KnowEnG uses internally
   2) user_gene_id: the corresponding gene/transcript/protein identifier supplied by the user in the original genomic spreadsheet.
 
-#### G) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
+#### D) gene_map_exceptions.txt - Gene ID Mapping Exceptions File (if KN guided analysis)
+- The columns of this file are defined as follows:
+  1) user_gene_id: the gene/transcript/protein identifier supplied by the user in the original genomic spreadsheet.
+  2) error_code: the reason the user_gene_id was not mapped to a stable Ensembl gene ID.
+
+#### E) dropped_genes.txt - Dropped Genes File
+- The columns of this file are defined as follows:
+  1) collection: the public gene set collection whose processing required dropping the gene
+  2) gene_name: the gene identifier as provided by the user in the original input
+  3) gene_id: the stable Ensembl gene ID for the gene_name
+
+#### F) run_params.yml - Run Parameters File
+- This yaml file contains the run parameters that were used by the computation container that ran the KnowEnG analysis pipeline (implementation available on GitHub) on the input data. The file contains one block of parameters per public gene set collection.
+
+#### G) run_cleanup_params.yml - Cleanup Run Parameters File
+- This yaml file contains the run parameters file that was used by the computation container that ran the KnowEnG data-cleanup pipeline (implementation available on GitHub) on the input data.
+
+#### H) property_networks.metadata - Gene Set Collection Metadata 
+- This yaml file contains information about the gene set collection used for the results.  There is one block per public gene set collection, and within each block, keys include summarizations about the network size (“data”), its public data source details (“datasets”), information about the meaning of its edges (“edge_type”), and some commands and configurations used in its construction (“export”).
+
+#### I) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
 - This yaml file contains information about the interaction network if used in the analysis.  Its keys include summarizations about the network size (“data”), its public data source details (“datasets”), information about the meaning of its edges (“edge_type”), and some commands and configurations used in its construction (“export”).
 
 The licensing terms of the source code and containers to perform this analysis can be found at https://knoweng.github.io/. Licensing information relating to the data in the Knowledge Network can be found https://knoweng.org/kn-data-references/#kn_data_resources. 

--- a/pipeline_readmes/README-SC.md
+++ b/pipeline_readmes/README-SC.md
@@ -1,4 +1,4 @@
-This file contains a description of the different output files of the sample clustering (SC) pipeline. The downloaded zip archive will contain up to eleven other files for users to further examine and understand their results.  These other files are:
+This file contains a description of the different output files of the sample clustering (SC) pipeline. The downloaded zip archive will contain up to ten other files for users to further examine and understand their results.  These other files are:
 
 #### Results Files
 - A) sample_labels_by_cluster.txt - Sample Cluster Assignment File
@@ -10,10 +10,9 @@ This file contains a description of the different output files of the sample clu
 #### Reference Files
 - F) clean_features_matrix.txt - Features Spreadsheet File (mapped if KN guided analysis)
 - G) gene_map.txt - Gene ID Mapping File (if KN guided analysis)
-- H) gene_map_exceptions.txt - Gene ID Mapping Exceptions File (if KN guided analysis)
-- I) run_params.yml - Run Parameters File
-- J) run_cleanup_params.yml - Cleanup Run Parameters File
-- K) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
+- H) run_params.yml - Run Parameters File
+- I) run_cleanup_params.yml - Cleanup Run Parameters File
+- J) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
 
 Below are descriptions for the contents of each of these files:
 
@@ -47,21 +46,16 @@ Below are descriptions for the contents of each of these files:
 
 #### G) gene_map.txt - Gene ID Mapping File (if KN guided analysis)
 - The columns of this file are defined as follows:
-    1) KN_gene_id: the stable Ensembl gene ID that KnowEnG uses internally
-    2) user_gene_id: the corresponding gene/transcript/protein identifier supplied by the user in the original genomic spreadsheet
+  1) user_supplied_gene_name: the gene/transcript/protein identifier supplied by the user in the original genomic spreadsheet.
+  2) status: if the user-supplied gene name could be mapped to a stable Ensembl gene ID, this column will contain the Ensembl gene ID; otherwise, this column will contain the reason mapping failed ("unmapped-none" if no match was found, or "unmapped-many" if multiple matches were found).
 
-#### H) gene_map_exceptions.txt - Gene ID Mapping Exceptions File (if KN guided analysis)
-- The columns of this file are defined as follows:
-  1) user_gene_id: the gene/transcript/protein identifier supplied by the user in the original genomic spreadsheet
-  2) error_code: the reason the user_gene_id was not mapped to a stable Ensembl gene ID
-
-#### I) run_params.yml - Run Parameters File
+#### H) run_params.yml - Run Parameters File
 - This yaml file contains the run parameters file that was used by the computation container that ran the KnowEnG analysis pipeline (implementation available on GitHub) on the input data.
 
-#### J) run_cleanup_params.yml - Cleanup Run Parameters File
+#### I) run_cleanup_params.yml - Cleanup Run Parameters File
 - This yaml file contains the run parameters file that was used by the computation container that ran the KnowEnG data-cleanup pipeline (implementation available on GitHub) on the input data.
 
-#### K) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
+#### J) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
 - This yaml file contains information about the interaction network if used in the analysis.  Its keys include summarizations about the network size (“data”), its public data source details (“datasets”), information about the meaning of its edges (“edge_type”), and some commands and configurations used in its construction (“export”).
 
 The licensing terms of the source code and containers to perform this analysis can be found at https://knoweng.github.io/. Licensing information relating to the data in the Knowledge Network can be found https://knoweng.org/kn-data-references/#kn_data_resources. 

--- a/pipeline_readmes/README-SC.md
+++ b/pipeline_readmes/README-SC.md
@@ -1,4 +1,4 @@
-This file contains a description of the different output files of the sample clustering (SC) pipeline. The downloaded zip archive will contain up to nine other files for users to further examine and understand their results.  These other files are:
+This file contains a description of the different output files of the sample clustering (SC) pipeline. The downloaded zip archive will contain up to eleven other files for users to further examine and understand their results.  These other files are:
 
 #### Results Files
 - A) sample_labels_by_cluster.txt - Sample Cluster Assignment File
@@ -10,8 +10,10 @@ This file contains a description of the different output files of the sample clu
 #### Reference Files
 - F) clean_features_matrix.txt - Features Spreadsheet File (mapped if KN guided analysis)
 - G) gene_map.txt - Gene ID Mapping File (if KN guided analysis)
-- H) run_params.yml - Run Parameters File
-- I) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
+- H) gene_map_exceptions.txt - Gene ID Mapping Exceptions File (if KN guided analysis)
+- I) run_params.yml - Run Parameters File
+- J) run_cleanup_params.yml - Cleanup Run Parameters File
+- K) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
 
 Below are descriptions for the contents of each of these files:
 
@@ -24,10 +26,10 @@ Below are descriptions for the contents of each of these files:
 - This file contains a matrix with the genomic spreadsheet sample_ids as the row and column names.  The values in the matrix indicate the proportion of the number of bootstraps where the corresponding samples co-cluster.  If bootstrapping was not used, these values will be binary {0, 1}. 
 
 #### C) top_features_by_cluster.txt - Cluster Features Spreadsheet File
-- This file contains a matrix with the cluster numbers as the columns headers and feature identifiers as the rows. If the KN was used in the analysis, feature identifiers will be the stable Ensembl gene_ids. A ‘1’ in this table indicates that the row feature was one of the top 100 most important (highest scoring) features for that specific column cluster.  All other values are 0.  Importance is calculated as the average value across the cluster.  If the Knowledge Network was used, then it is the average of the stationary probabilities of the random walks on each sample. If features are genes, this file can be used in the Gene Set Characterization pipeline.
+- This file contains a matrix with the cluster numbers as the columns headers and feature identifiers as the rows. A ‘1’ in this table indicates that the row feature was one of the top 100 most important (highest scoring) features for that specific column cluster.  All other values are 0.  Importance is calculated as the average value across the cluster.  If the Knowledge Network was used, then it is the average of the stationary probabilities of the random walks on each sample. If features are genes, this file can be used in the Gene Set Characterization pipeline.
 
 #### D) feature_avgs_by_cluster.txt - Cluster Means Spreadsheet File
-- This file contains a matrix with the cluster numbers as the columns headers and feature identifiers as the rows. If the KN was used in the analysis, feature identifiers will be the stable Ensembl gene_ids. The values in this table are the mean value for the row feature for that specific column cluster. If the Knowledge Network was used, then it is the average of the stationary probabilities of the random walks on each sample, otherwise it is the mean of the original input values.
+- This file contains a matrix with the cluster numbers as the columns headers and feature identifiers as the rows. The values in this table are the mean value for the row feature for that specific column cluster. If the Knowledge Network was used, then it is the average of the stationary probabilities of the random walks on each sample, otherwise it is the mean of the original input values.
 
 #### E) clustering_evalutations.txt - Phenotype Association File (if phenotypic input provided)
 - The columns of this file are defined as follows:
@@ -41,17 +43,25 @@ Below are descriptions for the contents of each of these files:
   8) Comments: NA for SUCCESS in Column 7, but descriptive message for FAIL case
 
 #### F) clean_features_matrix.txt - Features Spreadsheet File
-- This file contains the user's input feature matrix. If the KN was used in the analysis, the original gene identifiers provided are mapped to stable Ensembl gene_ids where possible, and rows with original gene names that are unable to be mapped or are not unique are discarded from this clean output.
+- This file contains the user's input feature matrix. If the KN was used in the analysis, rows with gene names that are unable to be mapped or are not unique are discarded from this clean output.
 
 #### G) gene_map.txt - Gene ID Mapping File (if KN guided analysis)
 - The columns of this file are defined as follows:
     1) KN_gene_id: the stable Ensembl gene ID that KnowEnG uses internally
-    2) user_gene_id: the corresponding gene/transcript/protein identifier supplied by the user in the original genomic spreadsheet.
+    2) user_gene_id: the corresponding gene/transcript/protein identifier supplied by the user in the original genomic spreadsheet
 
-#### H) run_params.yml - Run Parameters File
-- This yaml file contains the run parameters file that was used by the computation container that ran the KnowEnG pipeline (implementation available on GitHub) on the input data.
+#### H) gene_map_exceptions.txt - Gene ID Mapping Exceptions File (if KN guided analysis)
+- The columns of this file are defined as follows:
+  1) user_gene_id: the gene/transcript/protein identifier supplied by the user in the original genomic spreadsheet
+  2) error_code: the reason the user_gene_id was not mapped to a stable Ensembl gene ID
 
-#### I) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
+#### I) run_params.yml - Run Parameters File
+- This yaml file contains the run parameters file that was used by the computation container that ran the KnowEnG analysis pipeline (implementation available on GitHub) on the input data.
+
+#### J) run_cleanup_params.yml - Cleanup Run Parameters File
+- This yaml file contains the run parameters file that was used by the computation container that ran the KnowEnG data-cleanup pipeline (implementation available on GitHub) on the input data.
+
+#### K) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
 - This yaml file contains information about the interaction network if used in the analysis.  Its keys include summarizations about the network size (“data”), its public data source details (“datasets”), information about the meaning of its edges (“edge_type”), and some commands and configurations used in its construction (“export”).
 
 The licensing terms of the source code and containers to perform this analysis can be found at https://knoweng.github.io/. Licensing information relating to the data in the Knowledge Network can be found https://knoweng.org/kn-data-references/#kn_data_resources. 

--- a/pipeline_readmes/README-SC.md
+++ b/pipeline_readmes/README-SC.md
@@ -3,13 +3,13 @@ This file contains a description of the different output files of the sample clu
 #### Results Files
 - A) sample_labels_by_cluster.txt - Sample Cluster Assignment File
 - B) consensus_matrix.txt - Bootstrap Consensus Matrix File 
-- C) top_genes_by_cluster.txt - Cluster Genes Spreadsheet File
-- D) gene_avgs_by_cluster.txt - Cluster Means Spreadsheet File
+- C) top_features_by_cluster.txt - Cluster Features Spreadsheet File
+- D) feature_avgs_by_cluster.txt - Cluster Means Spreadsheet File
 - E) clustering_evalutations.txt - Phenotype Association File (if phenotypic input provided)
 
 #### Reference Files
-- F) clean_genomic_matrix.txt - Mapped Genomic Spreadsheet File
-- G) gene_map.txt - Gene ID Mapping File
+- F) clean_features_matrix.txt - Features Spreadsheet File (mapped if KN guided analysis)
+- G) gene_map.txt - Gene ID Mapping File (if KN guided analysis)
 - H) run_params.yml - Run Parameters File
 - I) interaction_network.metadata - Knowledge Network Metadata (if KN guided analysis)
 
@@ -23,11 +23,11 @@ Below are descriptions for the contents of each of these files:
 #### B) consensus_matrix.txt - Bootstrap Consensus Matrix File   
 - This file contains a matrix with the genomic spreadsheet sample_ids as the row and column names.  The values in the matrix indicate the proportion of the number of bootstraps where the corresponding samples co-cluster.  If bootstrapping was not used, these values will be binary {0, 1}. 
 
-#### C) top_genes_by_cluster.txt - Cluster Genes Spreadsheet File
-- This file contains a matrix with the cluster numbers as the columns headers and stable Ensembl gene_ids as the rows. A ‘1’ in this table indicates that the row gene was one of the top 100 most important (highest scoring) genes for that specific column cluster.  All other values are 0.  Importance is calculated as the average value across the cluster.  If the Knowledge Network was used, then it is the average of the stationary probabilities of the random walks on each sample. This file can be used in the Gene Set Characterization pipeline.
+#### C) top_features_by_cluster.txt - Cluster Features Spreadsheet File
+- This file contains a matrix with the cluster numbers as the columns headers and feature identifiers as the rows. If the KN was used in the analysis, feature identifiers will be the stable Ensembl gene_ids. A ‘1’ in this table indicates that the row feature was one of the top 100 most important (highest scoring) features for that specific column cluster.  All other values are 0.  Importance is calculated as the average value across the cluster.  If the Knowledge Network was used, then it is the average of the stationary probabilities of the random walks on each sample. If features are genes, this file can be used in the Gene Set Characterization pipeline.
 
-#### D) gene_avgs_by_cluster.txt - Cluster Means Spreadsheet File
-- This file contains a matrix with the cluster numbers as the columns headers and stable Ensembl gene_ids as the rows. The values in this table are the mean value for the row gene for that specific column cluster. If the Knowledge Network was used, then it is the average of the stationary probabilities of the random walks on each sample, otherwise it is the mean of the original input values.
+#### D) feature_avgs_by_cluster.txt - Cluster Means Spreadsheet File
+- This file contains a matrix with the cluster numbers as the columns headers and feature identifiers as the rows. If the KN was used in the analysis, feature identifiers will be the stable Ensembl gene_ids. The values in this table are the mean value for the row feature for that specific column cluster. If the Knowledge Network was used, then it is the average of the stationary probabilities of the random walks on each sample, otherwise it is the mean of the original input values.
 
 #### E) clustering_evalutations.txt - Phenotype Association File (if phenotypic input provided)
 - The columns of this file are defined as follows:
@@ -40,10 +40,10 @@ Below are descriptions for the contents of each of these files:
   7) SUCCESS/FAIL: For the given phenotype, whether or not a statistical test could be performed successfully
   8) Comments: NA for SUCCESS in Column 7, but descriptive message for FAIL case
 
-#### F) clean_genomic_matrix.txt - Mapped Genomic Spreadsheet File
-- This file contains a modified version of the user’s input genomic matrix where the original gene identifiers provided have been mapped to stable Ensembl gene_ids where possible.  When using the Knowledge Network guided analysis, rows with original gene names that are unable to be mapped or are not unique are discarded from this clean output.
+#### F) clean_features_matrix.txt - Features Spreadsheet File
+- This file contains the user's input feature matrix. If the KN was used in the analysis, the original gene identifiers provided are mapped to stable Ensembl gene_ids where possible, and rows with original gene names that are unable to be mapped or are not unique are discarded from this clean output.
 
-#### G) gene_map.txt - Gene ID Mapping File
+#### G) gene_map.txt - Gene ID Mapping File (if KN guided analysis)
 - The columns of this file are defined as follows:
     1) KN_gene_id: the stable Ensembl gene ID that KnowEnG uses internally
     2) user_gene_id: the corresponding gene/transcript/protein identifier supplied by the user in the original genomic spreadsheet.


### PR DESCRIPTION
Diffs below currently contain the unmerged/unapproved upstream PRs. If you'd like to see the changes new to this PR, they're all contained in this commit: https://github.com/KnowEnG/quickstart-demos/commit/6294f9cd892fda45f5f184cf5340361379ec77c9

The idea here is that DCP now produces a new file that captures the complete results--successes and failures--of gene-name mapping.  This new file replaces the two separate files (one for successes, one for unmapped-none (any unmapped-many names had to be inferred)) we previously provided in the download zip.